### PR TITLE
fix: encrypt zero size data

### DIFF
--- a/tensorizer/serialization.py
+++ b/tensorizer/serialization.py
@@ -3799,13 +3799,14 @@ class TensorSerializer:
             raise ValueError("dtype name length should be less than 256")
         header_pos = self._file.tell() if _start_pos is None else _start_pos
 
-        encrypted: bool = self._encrypted and has_data
+        encrypted: bool = self._encrypted and has_data and tensor_memory.nbytes > 0
         if encrypted:
             chunks = _Chunked(
                 total_size=tensor_memory.nbytes,
                 chunk_size=self._crypt_chunk_size,
             )
             nonces = self._new_nonces(chunks.count)
+
             encryptor = _crypt.ChunkedEncryption(
                 key=self._encryption.key,
                 buffer=tensor_memory,

--- a/tests/test_stream_io.py
+++ b/tests/test_stream_io.py
@@ -389,7 +389,7 @@ class TestS3(unittest.TestCase):
                 r"X-Amz-Credential=[A-Z]+",
             ]
             V2_regex = [
-                r"Expires=1[0-9]+",
+                r"(?<!X-Amz-)Expires=1[0-9]+",
                 r"AWSAccessKeyId=[A-Z]+",
             ]
 


### PR DESCRIPTION
## FIX
- vllm을 업데이트해서인지 명확한 원인을 알 수 없지만, w4a16 quantization하는 과정에서 발생한 에러를 수정합니다.
- encrypt할 데이터의 크기가 0인 것들이 모델에 있고, 이들을 encrypt하려고 하니 에러가 발생합니다.
- 이에 따라 size를 체크 및 0이라면 skip하는 코드를 추가합니다.